### PR TITLE
generalize analysis scripts to run on other setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ On Debian-based machines: `apt install python3 python3-numpy`.
 
 1. Place `*.pcap` and `*.pcapng` files in `captures/`
 2. Save Page Load Time statistics (saved as `*.plt_stats`) to `captures/`
-3. Run analysis: `cd end_to_end_rdns_analysis/analysis_scripts && python3 endtoendanalyzer.py`
-4. Read output: `cat end_to_end_rdns_analysis/out.txt`
+3. Save your backup file from WebTime Tracker (`webtime-tracker-backup-*.json`) to `captures/`
+4. Run analysis: `cd end_to_end_rdns_analysis/analysis_scripts && python3 endtoendanalyzer.py`
+5. Read output: `cat end_to_end_rdns_analysis/out.txt`

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ Example usage is in endtoendanalyzer:main.
 
 
 All pcaps go in the captures/ directory. Plot stats should also be in the captures directory, with file ending '.plt_stats'.
+
+## requirements
+
+* python3
+* python3-numpy
+
+On Debian-based machines: `apt install python3 python3-numpy`.
+
+## usage
+
+1. Place `*.pcap` and `*.pcapng` files in `captures/`
+2. Save Page Load Time statistics (saved as `*.plt_stats`) to `captures/`
+3. Run analysis: `cd end_to_end_rdns_analysis/analysis_scripts && python3 endtoendanalyzer.py`
+4. Read output: `cat end_to_end_rdns_analysis/out.txt`


### PR DESCRIPTION
Two major features and fixes:

1. Currently script assumes that the client and recursive resolver are sitting on the same machine (`127.0.0.1`). This PR parametrizes certain variables, letting you specify `local_ip` and `resolver_ip` in class instantiation. It also fixes some of the query analysis depending on whether the `local_ip` is set to `127.0.0.1` or otherwise.

2. Instead of manually creating the data structure from WebTime Tracker, you can copy the backup files from `webtime-tracker-backup-*.json` to `captures/` and the script will automatically parse it.